### PR TITLE
Server.js wildcard fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "chai": "^6.0.0",
-        "husky": "^9.0.0",
+        "husky": "^9.1.7",
         "mocha": "^11.0.0",
         "nodemon": "^3.0.1",
         "nyc": "^17.0.0",
@@ -63,7 +63,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1454,7 +1453,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2549,7 +2547,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },
@@ -4244,7 +4241,8 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "chai": "^6.0.0",
-    "husky": "^9.0.0",
+    "husky": "^9.1.7",
     "mocha": "^11.0.0",
     "nodemon": "^3.0.1",
     "nyc": "^17.0.0",

--- a/server.js
+++ b/server.js
@@ -51,7 +51,7 @@ function startServer() {
 
       app.use("/api", routes);
 
-      app.get("*", (req, res) => {
+      app.get(/(.*)/, (req, res) => {
         res.sendFile(path.join(guiBuild, "index.html"));
       });
 


### PR DESCRIPTION
With newer versions of expressjs, we have to [change the way](https://stackoverflow.com/questions/78973586/typeerror-invalid-token-at-1-https-git-new-pathtoregexperror) we resolve the wildcard domain. Wasn't able to run `node server.js` without making this change